### PR TITLE
Edicao perfil

### DIFF
--- a/PrjInterdisciplinar/src/app/Login/form-cadastro/form-cadastro.component.ts
+++ b/PrjInterdisciplinar/src/app/Login/form-cadastro/form-cadastro.component.ts
@@ -49,7 +49,7 @@ export class FormCadastroComponent implements OnInit{
       label:'Nome:',
       placeholder: 'Nome de usuário',
       required: true,
-      validators: ['required','minlength']
+      validators: ['required','minlength'],
     },
     {
       controlName:'email',

--- a/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.html
+++ b/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.html
@@ -1,0 +1,64 @@
+<div class="background"> <!-- background -->
+  <div class="container-fluid d-flex justify-content-center align-items-center flex-column"> <!-- Div do container-->
+    <!-- Formulário de Cadastro -->
+    <form [formGroup]="formCadastro" (ngSubmit)="onSubmit()"
+      class="form d-flex justify-content-center align-items-center flex-column m-3 p-4 rounded">
+      <h3 class="mb-4">Editar Perfil</h3>
+      <!-- Campos do formulário -->
+      <div class="row mt-3" style="width: 100%; max-width: 600px;">
+        <div class="col-md-6 col-sm-12 mb-3" *ngFor="let input of inputs">
+          <app-form-field
+            [formGroup]="this.formCadastro"
+            type = {{input.type}}
+            formName="form-cadastro"
+            controlName="{{input.controlName}}"
+            icon="{{input.icon}}"
+            label="{{input.label}}"
+            placeholder="{{input.placeholder}}"
+            [required]="input.required || false"
+            [validators]="input.validators || []"
+            [fieldType]="input.typeField || ''"
+          >
+          </app-form-field>
+        </div>
+        <hr>
+        <div class="col-md-6 col-sm-12 mb-3" *ngFor="let input of addressInputs">
+          <app-form-field
+            [formGroup]="this.formCadastro"
+            type = {{input.type}}
+            formName="form-cadastro"
+            controlName="{{input.controlName}}"
+            icon="{{input.icon}}"
+            label="{{input.label}}"
+            placeholder="{{input.placeholder}}"
+            [required]="input.required || false"
+            [validators]="input.validators || []"
+            [fieldType]="input.typeField || ''"
+          >
+          </app-form-field>
+        </div>
+      </div>
+
+      <!-- Caso algum dos controls esteja inválido -->
+      <span *ngIf="checkIfFormError('invalid-control')" class="texto-validacao-erro-form mb-1">
+        <img src="assets/login/erro_icon.svg" alt=""> Campos obrigatórios não preenchidos ou inválidos
+      </span>
+      <!-- Método checkIfFormError retorna true caso o erro específico esteja ocorrendo (parametro é o valor de string do enum)-->
+
+      <!-- Caso as senhas não coincidam -->
+      <span *ngIf="checkIfFormError('invalid-password')" class="texto-validacao-erro-form mb-1">
+        <img src="assets/login/erro_icon.svg" alt=""> Senhas não coincidem
+      </span>
+
+      <!-- Caso já exista um usuário -->
+      <span *ngIf="checkIfFormError('user-exists')" class="texto-validacao-erro-form mb-1">
+        <img src="assets/login/erro_icon.svg" alt=""> Já existe um usuário com esse email
+      </span>
+
+      <!-- Botão de entrar -->
+      <button class="mt-3 form-btn" type="submit">SALVAR</button>
+
+    </form> <!-- Fim do formulário -->
+  </div>
+</div>
+

--- a/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.spec.ts
+++ b/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EdicaoPerfilComponent } from './edicao-perfil.component';
+
+describe('EdicaoPerfilComponent', () => {
+  let component: EdicaoPerfilComponent;
+  let fixture: ComponentFixture<EdicaoPerfilComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EdicaoPerfilComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EdicaoPerfilComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.ts
+++ b/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.ts
@@ -1,0 +1,160 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormFieldComponent } from '../../Common/form-field/form-field.component';
+import { UserService } from '../../Services/user.service';
+import { ViacepService } from '../../Services/viacep.service';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { IFieldForm } from '../../models/fieldForm.model';
+import { CadastroErrorStatus } from '../../Login/form-cadastro/CadastroErrorStatus.enum';
+
+@Component({
+  selector: 'app-edicao-perfil',
+  standalone: true,
+  imports: [CommonModule, FormFieldComponent, ReactiveFormsModule],
+  templateUrl: './edicao-perfil.component.html',
+  styleUrl: './edicao-perfil.component.css'
+})
+export class EdicaoPerfilComponent {
+  protected cadastroErrorStatus : CadastroErrorStatus = CadastroErrorStatus.None;
+  private formBuilderService = inject(NonNullableFormBuilder);
+  private userService = inject(UserService);
+  private viacepService = inject(ViacepService);
+
+  formName : string = "cadastro"; //Nome do formulário para concatenar ao nome do control (email-cadastro)
+  passwordMinLength = 6;
+
+  protected formCadastro = this.formBuilderService.group({
+    nome : ['',[Validators.required, Validators.minLength(2)]],
+    email : ['', [Validators.required, Validators.email]],
+    senha : ['', [Validators.required, Validators.minLength(this.passwordMinLength)]],
+    confirmaSenha : ['', [Validators.required, Validators.minLength(this.passwordMinLength)]],
+    telefone : ['', [Validators.minLength(11), Validators.maxLength(11)]], //Opcional
+    cpf: ['',[Validators.minLength(11), Validators.maxLength(11)]],
+    cep : ['', [Validators.minLength(8), Validators.maxLength(8)]],  //Opcional
+    numero : [''],  //Opcional
+    logradouro : [''],  //Opcional
+    bairro : [''],  //Opcional
+    localidade : [''],  //Opcional
+    complemento : ['']
+  });
+  inputs : IFieldForm[] = [
+    {
+      controlName:'nome',
+      type : 'text',
+      icon:'assets/login/usuario_icon.svg',
+      label:'Nome:',
+      placeholder: 'Nome de usuário',
+      required: true,
+      validators: ['required','minlength']
+    },
+    {
+      controlName:'email',
+      type : 'email',
+      icon:'assets/login/email_icon.svg',
+      label:'Email:',
+      placeholder: 'Email de usuário',
+      required: true,
+      validators: ['required','email']
+    },
+    {
+      controlName:'senha',
+      type : 'password',
+      icon:'assets/login/senha_icon.svg',
+      label:'Senha:',
+      placeholder: 'Senha de login',
+      required: true,
+      validators: ['required','minlength']
+    },
+    {
+      controlName:'confirmaSenha',
+      type : 'password',
+      icon:'assets/login/senha_icon.svg',
+      label:'Confirme sua senha:',
+      placeholder: 'Confirmação da senha',
+      required: true,
+      validators: ['required','minlength']
+    },
+    {
+      controlName:'telefone',
+      type : 'tel',
+      icon:'assets/login/telefone_icon.svg',
+      label:'Telefone:',
+      placeholder: 'Telefone para contato',
+      required: false,
+      validators: ['minlength', 'maxlength']
+    },
+    {
+      controlName:'cpf',
+      type : 'text',
+      icon:'assets/login/cpf_icon.svg',
+      label:'CPF:',
+      placeholder: 'Digite seu CPF',
+      required: false,
+      validators: ['minlength', 'maxlength']
+    }
+  ];
+
+  addressInputs : IFieldForm[] = [
+    {
+      controlName:'cep',
+      type : 'text',
+      icon:'assets/login/endereco_icon.svg',
+      label:'CEP:',
+      placeholder: 'Digite seu CEP',
+      required: false,
+      validators: ['minlength', 'maxlength']
+    },
+    {
+      controlName:'logradouro',
+      type : 'text',
+      icon:'assets/login/endereco_icon.svg',
+      label:'Rua:',
+      placeholder: 'Digite sua rua',
+      required: false,
+    },
+    {
+      controlName:'bairro',
+      type : 'text',
+      icon:'assets/login/endereco_icon.svg',
+      label:'Bairro:',
+      placeholder: 'Digite seu bairro',
+      required: false,
+    },
+    {
+      controlName:'localidade',
+      type : 'text',
+      icon:'assets/login/endereco_icon.svg',
+      label:'Cidade:',
+      placeholder: 'Digite sua cidade',
+      required: false,
+    },
+    {
+      controlName:'numero',
+      type : 'text',
+      icon:'assets/login/endereco_icon.svg',
+      label:'Número:',
+      placeholder: 'Digite seu número',
+      required: false,
+    },
+    {
+      controlName:'complemento',
+      type : 'text',
+      icon:'assets/login/endereco_icon.svg',
+      label:'Complemento:',
+      placeholder: 'Digite seu complemento',
+      required: false,
+    },
+  ];
+
+    /* Método para verificar status do enum (CadastroErrorStatus.enum) */
+    checkIfFormError(status : string) : boolean{
+      /* Recebe o valor do enum (em string) e compara com o estado atual do formulário, se forem iguais, retorna true */
+      return this.cadastroErrorStatus == status
+    }
+
+  onSubmit() {
+    if(this.formCadastro.valid){
+      console.log("Formulário editado com sucesso")
+    }
+  }
+}

--- a/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.ts
+++ b/PrjInterdisciplinar/src/app/Usuario/edicao-perfil/edicao-perfil.component.ts
@@ -1,160 +1,250 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { FormFieldComponent } from '../../Common/form-field/form-field.component';
 import { UserService } from '../../Services/user.service';
 import { ViacepService } from '../../Services/viacep.service';
-import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { IFieldForm } from '../../models/fieldForm.model';
 import { CadastroErrorStatus } from '../../Login/form-cadastro/CadastroErrorStatus.enum';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-edicao-perfil',
   standalone: true,
   imports: [CommonModule, FormFieldComponent, ReactiveFormsModule],
   templateUrl: './edicao-perfil.component.html',
-  styleUrl: './edicao-perfil.component.css'
+  styleUrl: './edicao-perfil.component.css',
 })
-export class EdicaoPerfilComponent {
-  protected cadastroErrorStatus : CadastroErrorStatus = CadastroErrorStatus.None;
+export class EdicaoPerfilComponent implements OnInit {
+  protected cadastroErrorStatus: CadastroErrorStatus = CadastroErrorStatus.None;
   private formBuilderService = inject(NonNullableFormBuilder);
   private userService = inject(UserService);
   private viacepService = inject(ViacepService);
+  private router = inject(Router);
 
-  formName : string = "cadastro"; //Nome do formulário para concatenar ao nome do control (email-cadastro)
+  protected user = this.userService.getCurrentUser(); // obtem o objeto Usuario
+
+  formName: string = 'cadastro'; //Nome do formulário para concatenar ao nome do control (email-cadastro)
   passwordMinLength = 6;
 
   protected formCadastro = this.formBuilderService.group({
-    nome : ['',[Validators.required, Validators.minLength(2)]],
-    email : ['', [Validators.required, Validators.email]],
-    senha : ['', [Validators.required, Validators.minLength(this.passwordMinLength)]],
-    confirmaSenha : ['', [Validators.required, Validators.minLength(this.passwordMinLength)]],
-    telefone : ['', [Validators.minLength(11), Validators.maxLength(11)]], //Opcional
-    cpf: ['',[Validators.minLength(11), Validators.maxLength(11)]],
-    cep : ['', [Validators.minLength(8), Validators.maxLength(8)]],  //Opcional
-    numero : [''],  //Opcional
-    logradouro : [''],  //Opcional
-    bairro : [''],  //Opcional
-    localidade : [''],  //Opcional
-    complemento : ['']
+    nome: [this.user?.nome, [Validators.required, Validators.minLength(2)]],
+    email: [this.user?.email, [Validators.required, Validators.email]],
+    senha: [
+      this.user?.senha,
+      [Validators.required, Validators.minLength(this.passwordMinLength)],
+    ],
+    confirmaSenha: [
+      this.user?.senha,
+      [Validators.required, Validators.minLength(this.passwordMinLength)],
+    ],
+    telefone: [
+      this.user?.telefone,
+      [Validators.minLength(11), Validators.maxLength(11)],
+    ], //Opcional
+    cpf: [this.user?.cpf, [Validators.minLength(11), Validators.maxLength(11)]],
+    cep: [
+      this.user?.endereco?.cep,
+      [Validators.minLength(8), Validators.maxLength(8)],
+    ], //Opcional
+    numero: [this.user?.endereco?.numero], //Opcional
+    logradouro: [this.user?.endereco?.logradouro], //Opcional
+    bairro: [this.user?.endereco?.bairro], //Opcional
+    localidade: [this.user?.endereco?.cidade], //Opcional
+    complemento: [this.user?.endereco?.complemento], // Opcional
   });
-  inputs : IFieldForm[] = [
+  inputs: IFieldForm[] = [
     {
-      controlName:'nome',
-      type : 'text',
-      icon:'assets/login/usuario_icon.svg',
-      label:'Nome:',
+      controlName: 'nome',
+      type: 'text',
+      icon: 'assets/login/usuario_icon.svg',
+      label: 'Nome:',
       placeholder: 'Nome de usuário',
       required: true,
-      validators: ['required','minlength']
+      validators: ['required', 'minlength'],
     },
     {
-      controlName:'email',
-      type : 'email',
-      icon:'assets/login/email_icon.svg',
-      label:'Email:',
+      controlName: 'email',
+      type: 'email',
+      icon: 'assets/login/email_icon.svg',
+      label: 'Email:',
       placeholder: 'Email de usuário',
       required: true,
-      validators: ['required','email']
+      validators: ['required', 'email'],
     },
     {
-      controlName:'senha',
-      type : 'password',
-      icon:'assets/login/senha_icon.svg',
-      label:'Senha:',
+      controlName: 'senha',
+      type: 'password',
+      icon: 'assets/login/senha_icon.svg',
+      label: 'Senha:',
       placeholder: 'Senha de login',
       required: true,
-      validators: ['required','minlength']
+      validators: ['required', 'minlength'],
     },
     {
-      controlName:'confirmaSenha',
-      type : 'password',
-      icon:'assets/login/senha_icon.svg',
-      label:'Confirme sua senha:',
+      controlName: 'confirmaSenha',
+      type: 'password',
+      icon: 'assets/login/senha_icon.svg',
+      label: 'Confirme sua senha:',
       placeholder: 'Confirmação da senha',
       required: true,
-      validators: ['required','minlength']
+      validators: ['required', 'minlength'],
     },
     {
-      controlName:'telefone',
-      type : 'tel',
-      icon:'assets/login/telefone_icon.svg',
-      label:'Telefone:',
+      controlName: 'telefone',
+      type: 'tel',
+      icon: 'assets/login/telefone_icon.svg',
+      label: 'Telefone:',
       placeholder: 'Telefone para contato',
       required: false,
-      validators: ['minlength', 'maxlength']
+      validators: ['minlength', 'maxlength'],
     },
     {
-      controlName:'cpf',
-      type : 'text',
-      icon:'assets/login/cpf_icon.svg',
-      label:'CPF:',
+      controlName: 'cpf',
+      type: 'text',
+      icon: 'assets/login/cpf_icon.svg',
+      label: 'CPF:',
       placeholder: 'Digite seu CPF',
       required: false,
-      validators: ['minlength', 'maxlength']
-    }
+      validators: ['minlength', 'maxlength'],
+    },
   ];
 
-  addressInputs : IFieldForm[] = [
+  addressInputs: IFieldForm[] = [
     {
-      controlName:'cep',
-      type : 'text',
-      icon:'assets/login/endereco_icon.svg',
-      label:'CEP:',
+      controlName: 'cep',
+      type: 'text',
+      icon: 'assets/login/endereco_icon.svg',
+      label: 'CEP:',
       placeholder: 'Digite seu CEP',
       required: false,
-      validators: ['minlength', 'maxlength']
+      validators: ['minlength', 'maxlength'],
     },
     {
-      controlName:'logradouro',
-      type : 'text',
-      icon:'assets/login/endereco_icon.svg',
-      label:'Rua:',
+      controlName: 'logradouro',
+      type: 'text',
+      icon: 'assets/login/endereco_icon.svg',
+      label: 'Rua:',
       placeholder: 'Digite sua rua',
       required: false,
     },
     {
-      controlName:'bairro',
-      type : 'text',
-      icon:'assets/login/endereco_icon.svg',
-      label:'Bairro:',
+      controlName: 'bairro',
+      type: 'text',
+      icon: 'assets/login/endereco_icon.svg',
+      label: 'Bairro:',
       placeholder: 'Digite seu bairro',
       required: false,
     },
     {
-      controlName:'localidade',
-      type : 'text',
-      icon:'assets/login/endereco_icon.svg',
-      label:'Cidade:',
+      controlName: 'localidade',
+      type: 'text',
+      icon: 'assets/login/endereco_icon.svg',
+      label: 'Cidade:',
       placeholder: 'Digite sua cidade',
       required: false,
     },
     {
-      controlName:'numero',
-      type : 'text',
-      icon:'assets/login/endereco_icon.svg',
-      label:'Número:',
+      controlName: 'numero',
+      type: 'text',
+      icon: 'assets/login/endereco_icon.svg',
+      label: 'Número:',
       placeholder: 'Digite seu número',
       required: false,
     },
     {
-      controlName:'complemento',
-      type : 'text',
-      icon:'assets/login/endereco_icon.svg',
-      label:'Complemento:',
+      controlName: 'complemento',
+      type: 'text',
+      icon: 'assets/login/endereco_icon.svg',
+      label: 'Complemento:',
       placeholder: 'Digite seu complemento',
       required: false,
     },
   ];
 
-    /* Método para verificar status do enum (CadastroErrorStatus.enum) */
-    checkIfFormError(status : string) : boolean{
-      /* Recebe o valor do enum (em string) e compara com o estado atual do formulário, se forem iguais, retorna true */
-      return this.cadastroErrorStatus == status
-    }
+  /* Método para verificar status do enum (CadastroErrorStatus.enum) */
+  checkIfFormError(status: string): boolean {
+    /* Recebe o valor do enum (em string) e compara com o estado atual do formulário, se forem iguais, retorna true */
+    return this.cadastroErrorStatus == status;
+  }
 
   onSubmit() {
-    if(this.formCadastro.valid){
-      console.log("Formulário editado com sucesso")
+    //Verifica se o todos os campos obrigatórios foram preenchidos
+    if (this.formCadastro.valid) {
+      console.log('Formulário editado com sucesso');
+      this.router.navigate(['']);
     }
+  }
+  ngOnInit(): void {
+    //Verifica se estiver um usuário logado, caso não tenha, a página é direcionada para página inicial
+    if (this.user === null) {
+      this.router.navigate(['']);
+    }
+
+    // Detecta mudanças nos campos para resetar o status do erro atual
+    Object.keys(this.formCadastro.controls).forEach((control) => {
+      if (control != 'cep') {
+        this.formCadastro.get(control)?.valueChanges.subscribe(() => {
+          // Limpando o erro quando o usuário alterar o valor do campo 'senha'
+          this.cadastroErrorStatus = CadastroErrorStatus.None;
+        });
+      }
+    });
+
+    //VIACEP
+    this.formCadastro.controls.cep.valueChanges.subscribe(() => {
+      if (this.formCadastro.controls.cep !== undefined) {
+        if (
+          this.formCadastro.controls.cep.valid &&
+          this.formCadastro.controls.cep?.value?.length == 8
+        ) {
+          this.searchAddress(this.formCadastro.controls.cep.value);
+        } else {
+          console.log('CEP INVÁLIDO');
+          this.resetAddressControls();
+        }
+      }
+    });
+  }
+  searchAddress(cep: string) {
+    this.viacepService.getAddress(cep).subscribe({
+      next: (response) => {
+        if (response.logradouro) {
+          this.setAddressControl('logradouro', response.logradouro);
+        } else {
+          console.log('O logradouro não foi encontrado para o CEP informado.');
+        }
+
+        if (response.bairro) {
+          this.setAddressControl('bairro', response.bairro);
+        } else {
+          console.log('O logradouro não foi encontrado para o CEP informado.');
+        }
+
+        if (response.localidade) {
+          this.setAddressControl('localidade', response.localidade);
+        } else {
+          console.log('O logradouro não foi encontrado para o CEP informado.');
+        }
+      },
+      error: (e) => {
+        console.log(e);
+      },
+    });
+  }
+
+  resetAddressControls() {
+    let addressControls = ['logradouro', 'bairro', 'localidade'];
+    addressControls.forEach((field) => {
+      this.formCadastro.get(field)!.reset();
+    });
+  }
+
+  private setAddressControl(control: string, value: string) {
+    this.formCadastro.get(control)?.setValue(value);
   }
 }

--- a/PrjInterdisciplinar/src/app/app.routes.ts
+++ b/PrjInterdisciplinar/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { FormCadastroComponent } from './Login/form-cadastro/form-cadastro.compo
 import { ComentarioCentralComponent } from './Comentario/comentario-central/comentario-central.component';
 import { ReclamacaoFormComponent } from './Reclamacao/reclamacao-form/reclamacao-form.component';
 import { FormDoencaComponent } from './Doenca/form-doenca/form-doenca.component';
+import { EdicaoPerfilComponent } from './Usuario/edicao-perfil/edicao-perfil.component';
 
 
 export const routes: Routes = [
@@ -29,6 +30,7 @@ export const routes: Routes = [
   {path: 'cadastro', component:FormCadastroComponent},
   {path: 'comentario/:idReclamamacao',component:ComentarioCentralComponent},
   {path: 'reclamacao-form', component: ReclamacaoFormComponent},
-  {path: 'doenca-form', component: FormDoencaComponent}
+  {path: 'doenca-form', component: FormDoencaComponent},
+  {path: 'editar-perfil', component: EdicaoPerfilComponent}
 
 ];


### PR DESCRIPTION
Criado a Edição Perfil. Usando a tela de form cadastro, copiei os métodos e propriedades usados e remodelando eles para atender as minhas necessidades. A tela ficou idêntica ao cadastro, como era proposto, com leves alterações para que se parecesse uma tela de edição de perfil.
A página só é carregada se o usuário estiver logado, caso contrário, ele redirecionado para a página principal. Também adicionei o comportamento de assim que carregada a página, ela obtém junto consigo os dados do formulário já preenchidos, somente esperando o usuário editar. Se todos os campos obrigatórios forem preenchidos, e o usuário apertar o botão de Salvar, o usuário é redirecionado para a página principal e um console log apresenta a mensagem que foi submetido com sucesso.